### PR TITLE
Update colour of nav links in header

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,8 @@
 module.exports = {
   siteMetadata: {
-    title: `Code 4 Covid`,
+    title: `Code4Covid`,
     description: `Help fight Covid-19 with the tech community`,
-    author: `@gatsbyjs`,
+    author: `@code4covid`,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
@@ -46,6 +46,14 @@ module.exports = {
         trackingId: "UA-162006761-1",
       },
     },
+    {
+      resolve: "gatsby-plugin-react-svg",
+      options: {
+        rule: {
+          include: /images/,
+        }
+      }
+    }
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4710,6 +4710,24 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -7922,7 +7940,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
@@ -8656,6 +8675,14 @@
       "integrity": "sha512-kLR/RMDBVriJptsJufoL1UBVHgq2fZIMXen7nru2ugGn0m8xwpArFoOz6meYlpiDB3Z41eYR/+Nr8GizQnYcxg==",
       "requires": {
         "@babel/runtime": "^7.8.7"
+      }
+    },
+    "gatsby-plugin-react-svg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-svg/-/gatsby-plugin-react-svg-3.0.0.tgz",
+      "integrity": "sha512-myZl5NjVZwLLn4ovwSDM7cufa8yjaRiU5KoufJrz8FEalRroZ/hFSCCKNVna3blTwxcS0rZgISigYn9/xY7rkw==",
+      "requires": {
+        "svg-react-loader": "^0.4.4"
       }
     },
     "gatsby-plugin-sharp": {
@@ -13647,6 +13674,11 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
+    "ramda": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
+      "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -14611,6 +14643,11 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -15893,6 +15930,58 @@
         "has-flag": "^3.0.0"
       }
     },
+    "svg-react-loader": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/svg-react-loader/-/svg-react-loader-0.4.6.tgz",
+      "integrity": "sha512-HVEypjWQsQuJdBIPzXGxpmQsQts7QwfQuYgK1rah6BVCMoLNSCh/ESKVNd7/tHq8DkWYHHTyaUMDA1FjqZYrgA==",
+      "requires": {
+        "css": "2.2.4",
+        "loader-utils": "1.1.0",
+        "ramda": "0.21.0",
+        "rx": "4.1.0",
+        "traverse": "0.6.6",
+        "xml2js": "0.4.17"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
+        },
+        "xml2js": {
+          "version": "0.4.17",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+          "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "^4.1.0"
+          }
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "requires": {
+            "lodash": "^4.0.0"
+          }
+        }
+      }
+    },
     "svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -16276,6 +16365,11 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7922,8 +7922,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "resolved": "",
               "optional": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gatsby-plugin-offline": "^3.0.41",
     "gatsby-plugin-prefetch-google-fonts": "^1.4.3",
     "gatsby-plugin-react-helmet": "^3.1.24",
+    "gatsby-plugin-react-svg": "^3.0.0",
     "gatsby-plugin-sharp": "^2.5.3",
     "gatsby-source-filesystem": "^2.1.56",
     "gatsby-transformer-sharp": "^2.4.2",

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,10 +1,10 @@
 import PropTypes from "prop-types"
 import React from "react"
-import { Box, Image, Flex, Heading, ListItem, List, Link as InlineLink } from '@chakra-ui/core';
-import { Link } from "gatsby";
+import { Box, Flex, Heading, ListItem, List, Link } from '@chakra-ui/core';
+import { Link as GatsbyLink } from "gatsby";
 
-import code4coviddark from "../images/code4coviddark.svg"
-import twitterIcon from "../images/twitter-icon.svg"
+import Code4CovidDark from "../images/code4coviddark.svg"
+import TwitterIcon from "../images/twitter-icon.svg"
 
 const Footer = () => (
   <Flex
@@ -21,31 +21,21 @@ const Footer = () => (
       </Heading>
       <List textDecoration="underline" lineHeight={2}>
         <ListItem>
-          <Link to="/support-resources">Support Resources</Link>
+          <GatsbyLink to="/support-resources">Support Resources</GatsbyLink>
         </ListItem>
         <ListItem>
-          <Link to="/tech-volunteers">Tech Volunteers</Link>
+          <GatsbyLink to="/tech-volunteers">Tech Volunteers</GatsbyLink>
         </ListItem>
         <ListItem>
-          <InlineLink href="https://twitter.com/code4covid" isExternal>
-              <Image
-                src={twitterIcon}
-                alt="Twitter Icon"
-                display="inline-block"
-                marginRight="0.5rem"
-                width="25px"
-              />
-            Twitter
-          </InlineLink>
+          <Link href="https://twitter.com/code4covid" isExternal>
+            <TwitterIcon width={25} style={{ display: "inline" }} />
+            <Box as="span" marginLeft="10px">Twitter</Box>
+          </Link>
         </ListItem>
       </List>
     </Box>
     <Flex alignSelf="flex-end">
-      <Image
-        src={code4coviddark}
-        alt="code4covidLogo"
-        width={[125, 200]}
-      />
+      <Code4CovidDark width={150} />
     </Flex>
   </Flex>
 )

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -9,7 +9,7 @@ import twitterIcon from "../images/twitter-icon.svg"
 const Footer = () => (
   <Flex
     as="footer"
-    backgroundColor="#2F3B45"
+    backgroundColor="gray.700"
     paddingX={["1rem", "4.5rem"]}
     paddingY={"2rem"}
     justifyContent="space-between"

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -13,12 +13,12 @@ import {
   Image,
   useDisclosure,
   css,
-  Link as InlineLink,
+  Link,
 } from "@chakra-ui/core"
 import React from "react"
 import code4covid from "../images/code4covid.svg"
 import twitterIcon from "../images/twitter-icon.svg";
-import { Link } from "gatsby"
+import { Link as GatsbyLink } from "gatsby"
 
 const PAGES = [
   { children: "Home", to: "/" },
@@ -27,7 +27,7 @@ const PAGES = [
 ]
 
 const NavLink = props => (
-  <Button variant="ghost" fontSize="20px" as={Link} fontWeight={500} {...props} />
+  <Button variant="ghost" fontSize="20px" as={GatsbyLink} fontWeight={500} {...props}/>
 )
 
 const Header = () => {
@@ -65,14 +65,19 @@ const Header = () => {
       >
         {PAGES.map(page => (
           <NavLink
+            _hover={{ color: "gray.400" }}
             color="gray.700"
             fontWeight={700}
-            _hover={{ color: "gray.400" }}
             key={page.children + page.to}
+            css={css`
+              [aria-current]& {
+                color: #A0AEC0;
+              }
+            `}
             {...page}
           />
         ))}
-        <InlineLink href="https://twitter.com/code4covid" isExternal>
+        <Link href="https://twitter.com/code4covid" isExternal>
           <Image
             src={twitterIcon}
             alt="Twitter link"
@@ -80,7 +85,7 @@ const Header = () => {
             marginLeft="1rem"
             width="25px"
           />
-        </InlineLink>
+        </Link>
       </Stack>
       <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
         <DrawerOverlay />
@@ -102,14 +107,14 @@ const Header = () => {
                     {...page}
                   />
                 ))}
-                <InlineLink textAlign="center" href="https://twitter.com/code4covid" isExternal>
+                <Link textAlign="center" href="https://twitter.com/code4covid" isExternal>
                   <Image
                     src={twitterIcon}
                     alt="Twitter link"
                     display="inline-block"
                     width="40px"
                   />
-                </InlineLink>
+                </Link>
               </Stack>
             </DrawerBody>
           </DrawerContent>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -72,9 +72,16 @@ const Header = () => {
             {...page}
           />
         ))}
-        <Link href="https://twitter.com/code4covid" name="Twitter" isExternal>
-          <TwitterIcon width="25px" style={{display: "inline"}} role="img"/>
-        </Link>
+        <Button
+          as={Link}
+          variant="ghost"
+          _hover={{}}
+          target="blank"
+          href="https://twitter.com/code4covid"
+          name="Twitter"
+        >
+          <TwitterIcon width={25} height={25} style={{ display: "inline-block" }} role="img"/>
+        </Button>
       </Stack>
       <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
         <DrawerOverlay />

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -10,14 +10,13 @@ import {
   DrawerContent,
   DrawerCloseButton,
   DrawerBody,
-  Image,
   useDisclosure,
   css,
   Link,
 } from "@chakra-ui/core"
 import React from "react"
-import code4covid from "../images/code4covid.svg"
-import twitterIcon from "../images/twitter-icon.svg";
+import Code4Covid from "../images/code4covid.svg"
+import TwitterIcon from "../images/twitter-icon.svg";
 import { Link as GatsbyLink } from "gatsby"
 
 const PAGES = [
@@ -43,11 +42,7 @@ const Header = () => {
       alignItems="center"
     >
       <Link to="/">
-        <Image
-          src={code4covid}
-          alt="code4covidLogo"
-          width={[125, 200]}
-        />
+        <Code4Covid width={200}/>
       </Link>
       <IconButton
         display={["block", "block", "none"]} // Match this with the inverse of the buttons stack to use Chakra breakpoints
@@ -77,14 +72,8 @@ const Header = () => {
             {...page}
           />
         ))}
-        <Link href="https://twitter.com/code4covid" isExternal>
-          <Image
-            src={twitterIcon}
-            alt="Twitter link"
-            display="inline-block"
-            marginLeft="1rem"
-            width="25px"
-          />
+        <Link href="https://twitter.com/code4covid" name="Twitter" isExternal>
+          <TwitterIcon width="25px" style={{display: "inline"}} role="img"/>
         </Link>
       </Stack>
       <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
@@ -108,12 +97,7 @@ const Header = () => {
                   />
                 ))}
                 <Link textAlign="center" href="https://twitter.com/code4covid" isExternal>
-                  <Image
-                    src={twitterIcon}
-                    alt="Twitter link"
-                    display="inline-block"
-                    width="40px"
-                  />
+                  <TwitterIcon width="40px" style={{ display: "inline-block" }} />
                 </Link>
               </Stack>
             </DrawerBody>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -64,7 +64,13 @@ const Header = () => {
         spacing={1}
       >
         {PAGES.map(page => (
-          <NavLink key={page.children + page.to} fontWeight={700} color="gray.400" {...page} />
+          <NavLink
+            color="gray.700"
+            fontWeight={700}
+            _hover={{ color: "gray.400" }}
+            key={page.children + page.to}
+            {...page}
+          />
         ))}
         <InlineLink href="https://twitter.com/code4covid" isExternal>
           <Image

--- a/src/gatsby-plugin-chakra-ui/theme.js
+++ b/src/gatsby-plugin-chakra-ui/theme.js
@@ -7,6 +7,15 @@ export default {
     body: "Montserrat, sans-serif",
     heading: "Montserrat, sans-serif",
   },
+  colors: {
+    ...theme.colors,
+    gray: {
+      ...theme.colors.gray,
+      700: "#2F3B45",
+    },
+    purple: "#B56AFF",
+    yellow: "#FFEE56",
+  },
   icons: {
     ...theme.icons,
     menu: {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,7 +14,7 @@ const headerStyling = {
 }
 
 const buttonStyling = {
-  backgroundColor: "#FFEE56",
+  backgroundColor: "yellow",
   margin: "40px 0px",
 }
 
@@ -22,7 +22,7 @@ const IndexPage = () => (
   <Layout>
     <SEO title="Home" />
     <Section
-      backgroundColor={"#B56AFF"}
+      backgroundColor={"purple"}
       paddingY={[1,8]}
     >
       <Heading {...headerStyling}>Need help in <br/> Quarantine?</Heading>

--- a/src/pages/support-resources.js
+++ b/src/pages/support-resources.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Text } from '@chakra-ui/core'
+
 import Layout from '../components/layout'
+import SEO from "../components/seo"
 import Section from '../components/section'
 
 const SupportResources = () => (
   <Layout>
+    <SEO title="Support Resources" />
     <Section>
       <Text>Coming soon..</Text>
     </Section>

--- a/src/pages/tech-volunteers-form.js
+++ b/src/pages/tech-volunteers-form.js
@@ -10,7 +10,7 @@ const TechVolunteersForm = () => {
 
   return (
   <Layout>
-      <SEO title="Home" />
+      <SEO title="Tech Volunteers Form" />
       <Box textAlign="center">
         <Spinner ref={spinnerRef} marginTop={200}/>
 

--- a/src/pages/tech-volunteers.js
+++ b/src/pages/tech-volunteers.js
@@ -15,7 +15,7 @@ const headerStyling = {
 }
 
 const buttonStyling = {
-  backgroundColor: "#FFEE56",
+  backgroundColor: "yellow",
   marginY: 10,
 }
 
@@ -32,7 +32,7 @@ const TechVolunteers = () => {
       <SEO title="Home" />
 
       <Section
-        backgroundColor={"#B56AFF"}
+        backgroundColor={"purple"}
         paddingY={[1,8]}
       >
         <Heading {...headerStyling}>Hello and welcome,<br/> fellow Technologists!</Heading>

--- a/src/pages/tech-volunteers.js
+++ b/src/pages/tech-volunteers.js
@@ -29,7 +29,7 @@ const textStyling = {
 const TechVolunteers = () => {
   return (
     <Layout>
-      <SEO title="Home" />
+      <SEO title="Tech Volunteers" />
 
       <Section
         backgroundColor={"purple"}


### PR DESCRIPTION
Main visual change is to make the nav links black by default, grey when you hover on them and grey when the page is the current one.

<img width="624" alt="Screen Shot 2020-03-27 at 7 06 00 pm" src="https://user-images.githubusercontent.com/633926/77735169-2ba9b380-705e-11ea-86eb-9db2879e41dc.png">

I also changed the SVGs to be inline because this stops an issue where the images reload each time the page changes. This causes a jarring flickering when changing pages. Compare:

https://loving-hamilton-c8743a.netlify.com/

with

https://5e7db340cb34d100072b3d35--loving-hamilton-c8743a.netlify.com/