### PR TITLE
Try different approach to hiding the spinner after iFrame load

### DIFF
--- a/src/pages/partner-with-us.js
+++ b/src/pages/partner-with-us.js
@@ -1,18 +1,16 @@
-import React, { useRef } from "react"
+import React, { useState } from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { Spinner, Box } from "@chakra-ui/core"
 
 const PartnerWithUs = () => {
-  const spinnerRef = useRef()
-
-  const hideSpinner = () => (spinnerRef.current.style.display = "none")
+  const [isLoading, setIsLoading] = useState(true);
 
   return (
     <Layout>
       <SEO title="Partner With Us" />
       <Box textAlign="center">
-        <Spinner ref={spinnerRef} marginTop={200} />
+        {isLoading && <Spinner marginTop={200} />}
 
         <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js" />
         <iframe
@@ -23,7 +21,7 @@ const PartnerWithUs = () => {
           width="100%"
           height="3050"
           background="transparent"
-          onLoad={hideSpinner}
+          onLoad={() => setIsLoading(false)}
         />
       </Box>
     </Layout>

--- a/src/pages/tech-volunteers-form.js
+++ b/src/pages/tech-volunteers-form.js
@@ -1,18 +1,16 @@
-import React, { useRef } from "react"
+import React, { useState } from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { Spinner, Box } from "@chakra-ui/core"
 
 const TechVolunteersForm = () => {
-  const spinnerRef = useRef();
-
-  const hideSpinner = () => spinnerRef.current.style.display = 'none';
+  const [isLoading, setIsLoading] = useState(true);
 
   return (
-  <Layout>
+    <Layout>
       <SEO title="Tech Volunteers Form" />
       <Box textAlign="center">
-        <Spinner ref={spinnerRef} marginTop={200}/>
+        {isLoading && <Spinner marginTop={200}/>}
 
         <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script>
         <iframe
@@ -23,7 +21,7 @@ const TechVolunteersForm = () => {
           width="100%"
           height="2330"
           background="transparent"
-          onLoad={hideSpinner}
+          onLoad={() => setIsLoading(false)}
         ></iframe>
       </Box>
     </Layout>


### PR DESCRIPTION
Sometimes the spinner continues to show even after the iFrame loads. Very hard to reproduce locally. Not sure exactly why - trying this alternative approach to see if it helps.

Suggestions very welcome for a better solution or thing to try!