### PR TITLE
Revert 'Get Tech Support' back to the correct link

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ const IndexPage = () => (
       paddingY={[1,8]}
     >
       <Heading {...headerStyling}>Need tech resources <br/> for a project?</Heading>
-      <Link href="https://covidtechsupport.com/" isExternal>
+      <Link href="https://covidtechsupport.com/about/" isExternal>
         <Button {...buttonStyling}>GET TECH SUPPORT</Button>
       </Link>
       <Heading {...headerStyling}>


### PR DESCRIPTION
- Reverted tech support link back to https://covidtechsupport.com/about/
- Change is described in task 11 on Trello: https://trello.com/c/r19glqB0/5-main-website